### PR TITLE
fix: packages dependencies & animted rename 

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ export interface Props {
   fontStyle?: StyleProp<TextStyle>
   animationDuration?: number
   includeComma?: boolean
-  easing?: Animated.EasingFunction
+  easing?: Animated.EasingNodeFunction
 }
 
 declare const AnimatedNumber: React.SFC<Props>

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Text, View } from 'react-native';
-import Animated, { Easing } from 'react-native-reanimated';
+import Animated, { EasingNode } from 'react-native-reanimated';
 
 const NUMBERS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 
@@ -85,7 +85,7 @@ const AnimatedNumber = ({
 				toValue: -1 * (numberHeight * animateToNumbersArr[index]),
 				duration: animationDuration || 1400,
 				useNativeDriver: true,
-				easing: easing || Easing.elastic(1.2),
+				easing: easing || EasingNode.elastic(1.2),
 			}).start();
 		});
 	}, [animateToNumber, numberHeight]);

--- a/package.json
+++ b/package.json
@@ -37,8 +37,5 @@
     "eslint": "^7.4.0",
     "eslint-plugin-react": "^7.20.3"
   },
-  "dependencies": {
-    "react-native-reanimated": "^1.10.2",
-    "react-native-gesture-handler": "^1.7.0"
-  }
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
     "eslint": "^7.4.0",
     "eslint-plugin-react": "^7.20.3"
   },
-  "dependencies": {}
+  "peerDependencies": {
+      "react-native-reanimated": "^2",
+      "react-native-gesture-handler": "^2"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -31,14 +31,16 @@
   "homepage": "https://github.com/heyman333/react-native-animated-numbers/blob/master/README.md",
   "peerDependencies": {
     "react": ">=16.8.0",
-    "react-native": ">=0.59"
+    "react-native": ">=0.59",
+    "react-native-reanimated": ">=2",
+    "react-native-gesture-handler": "1.10.3"
   },
   "devDependencies": {
     "eslint": "^7.4.0",
     "eslint-plugin-react": "^7.20.3"
   },
-  "peerDependencies": {
-      "react-native-reanimated": "^2",
-      "react-native-gesture-handler": "^2"
+  "dependencies": {
+    "react-native-reanimated": "^2.2.4",
+    "react-native-gesture-handler": "^1.10.3"
   }
 }


### PR DESCRIPTION
Hi, I very like this project.Now a lot of people are using react-native-reanimted v2.
Upgrading to react-native-reanimted v2 is highly recommended. 😄
So:
- Project's react-native-reanimted version should depend on myself project.
- fix: "WARN  Easing was renamed to EasingNode in Reanimated 2. Please use EasingNode instead"


So this PR is for v2, thanks!!!
