### PR TITLE
fix: Property storage exceeds 196607 properties, js engine: hermes

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Text, View } from 'react-native';
 import Animated, { EasingNode } from 'react-native-reanimated';
 
-const NUMBERS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+const NUMBERS = Array(10).fill()..map((_, i) => i);
 
 const usePrevious = (value) => {
 	const ref = React.useRef();


### PR DESCRIPTION
There's an error while using Hermes Engine: RangeError: Property storage exceeds 196607 properties, js engine: hermes.

This is caused by not using a proper array.

You can refer to this issue here: 
https://github.com/facebook/hermes/issues/139

And the comment:
https://github.com/facebook/hermes/issues/139#issuecomment-1017785817