### PR TITLE
feat: add default fontVariant

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ yarn add react-native-animated-numbers
 | animationDuration |  number?   |      1400(ms)       | The speed at which the animation works |
 |   includeComma    |  boolean?  |        false        | Whether the number contains commas     |
 |      easing       |  Easing?   | Easing.elastic(1.2) | React Native Easing API in Animated    |
+|  containerStyle   | ViewStyle? |        none         | Style of container view                |
+|    fontVariant    |  string[]  |  ['tabular-nums']   | Font variants for a font               |
 
 ## example
 

--- a/src/components/AnimatedNumber.tsx
+++ b/src/components/AnimatedNumber.tsx
@@ -8,6 +8,7 @@ import type {
 import { Text, View, Animated, Easing, StyleSheet } from 'react-native';
 import usePrevious from '../hooks/usePrevious';
 import { createNumberArrayWithComma, toAbsoluteInteger } from '../utils';
+import { DEFAULT_FONT_VARIANT } from '../constants';
 
 export interface AnimatedNumberProps {
   animateToNumber: number;
@@ -16,6 +17,7 @@ export interface AnimatedNumberProps {
   includeComma?: boolean;
   easing?: Animated.TimingAnimationConfig['easing'];
   containerStyle?: StyleProp<ViewStyle>;
+  fontVariant?: TextStyle['fontVariant'];
 }
 
 const AnimatedNumber = ({
@@ -25,6 +27,7 @@ const AnimatedNumber = ({
   includeComma,
   easing,
   containerStyle,
+  fontVariant = DEFAULT_FONT_VARIANT,
 }: AnimatedNumberProps) => {
   const animationRef = useRef<Animated.CompositeAnimation | null>(null);
 
@@ -144,7 +147,13 @@ const AnimatedNumber = ({
                   ]}
                 >
                   {NUMBERS.map((number, i) => (
-                    <Text style={[fontStyle, { height }]} key={i}>
+                    <Text
+                      style={StyleSheet.flatten([
+                        fontStyle,
+                        { fontVariant, height },
+                      ])}
+                      key={i}
+                    >
                       {number}
                     </Text>
                   ))}

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,5 @@
+import type { TextStyle } from 'react-native';
+
+export const DEFAULT_FONT_VARIANT = [
+  'tabular-nums',
+] satisfies TextStyle['fontVariant'];


### PR DESCRIPTION
## Setting Default Font Variants

Thanks for merge previous pull request! 🙇🏻‍♂️ 

I had same issue mentioned at https://github.com/heyman333/react-native-animated-numbers/issues/38

Why don't we set default font variant of `tabular-nums`, which seems suitable for this library?

Both checked iOS & Android working fine. 

Thank you! 